### PR TITLE
Fix package installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ deno run https://deno.land/x/qrcode/cli.ts <text>
 You can also install it globally using the following:
 
 ```bash
-deno install qrcode https://deno.land/x/qrcode/cli.ts
+deno install https://deno.land/x/qrcode/cli.ts
 ```
 
 Then, the package is available to run:


### PR DESCRIPTION
Remove ``qrcode`` arguments in  installation command  because adding them causes a problem during execution
the correct command is:
```bash
deno install https://deno.land/x/qrcode/cli.ts
```
the default executable name is the file name or parent folder in this case ``qrcode`` is the executable name of the package 
or you can use it as executable name of the package by adding ``-n`` Or ``--name`` flags before it
```bash
deno install -n qrcode https://deno.land/x/qrcode/cli.ts
```

[Deno - Script installer](https://deno.land/manual/tools/script_installer)