### PR TITLE
:recycle: Fix semantic-release repository metadata

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -34,11 +34,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: latest
       - name: Setup package.json
-        run: echo '{"name":"@denorg/qrcode","version":"0.0.0","publishConfig":{"access":"public"},"scripts":{"semantic-release":"semantic-release"},"repository":{"type":"git","url":"git@github.com:actions/checkout.git"},"author":"Denorg <hi@den.org.in>","license":"MIT","bugs":{"url":"https://github.com/denorg/qrcode/issues"},"homepage":"https://denorg.github.io/qrcode/","devDependencies":{"semantic-release":"^17.0.4","semantic-release-gitmoji":"^1.3.3"}}' > package.json
+        run: echo '{"name":"@denorg/qrcode","version":"0.0.0","publishConfig":{"access":"public"},"scripts":{"semantic-release":"semantic-release"},"repository":{"type":"git","url":"git@github.com:denorg/qrcode.git"},"author":"Denorg <hi@den.org.in>","license":"MIT","bugs":{"url":"https://github.com/denorg/qrcode/issues"},"homepage":"https://denorg.github.io/qrcode/","devDependencies":{"semantic-release":"^17.0.4","semantic-release-gitmoji":"^1.3.3"}}' > package.json
       - name: Install dependencies
         run: npm install
       - name: Release


### PR DESCRIPTION
## Summary
- Correct the temporary release `package.json` repository URL from `actions/checkout` to `denorg/qrcode`.
- Update the release job from `actions/setup-node@v3` to `v4` so local workflow validation passes on current Actions runtime checks.

## Why
After #19 merged, `Deno CI` passed but semantic-release did not publish because it resolved release metadata against `actions/checkout` and reported the local `master` branch was behind that remote.

## Test plan
- `actionlint -stdin-filename .github/workflows/deno.yml -`
- `/tmp/deno-bin/deno test --allow-read --coverage=coverage`
- `/tmp/deno-bin/deno coverage coverage`
